### PR TITLE
fix: update history import method

### DIFF
--- a/packages/smallfish-plugin-router/src/history.ts
+++ b/packages/smallfish-plugin-router/src/history.ts
@@ -1,1 +1,3 @@
-export default window.g_history;
+import history from '@tmp/history';
+
+export default history;


### PR DESCRIPTION
修复 history 引用的问题。

umi 已去除 g_history 全局变量